### PR TITLE
WebDAV directory listing should be compressed

### DIFF
--- a/xbmc/filesystem/DAVDirectory.cpp
+++ b/xbmc/filesystem/DAVDirectory.cpp
@@ -116,6 +116,7 @@ bool CDAVDirectory::GetDirectory(const CURL& url, CFileItemList &items)
   dav.SetCustomRequest(strRequest);
   dav.SetMimeType("text/xml; charset=\"utf-8\"");
   dav.SetRequestHeader("depth", 1);
+  dav.SetRequestHeader("Accept-Encoding", "gzip, deflate");
   dav.SetPostData(
     "<?xml version=\"1.0\" encoding=\"utf-8\" ?>"
     " <D:propfind xmlns:D=\"DAV:\">"


### PR DESCRIPTION
As explained in http://forum.kodi.tv/showthread.php?tid=253090.

PROPFIND response is XML very easily compressible. Even considering the compression/decompresion CPU cycles, it should be faster in the network.
